### PR TITLE
Swap custom metadata format for YAML

### DIFF
--- a/pack/effects/noblue/effect.meta
+++ b/pack/effects/noblue/effect.meta
@@ -1,4 +1,0 @@
-Name = No blue
-Version = 1.1
-Author = qeaml <qeaml@pm.me>
-Desc = Set the blue value of all pixels to 0.

--- a/pack/effects/noblue/effect.yml
+++ b/pack/effects/noblue/effect.yml
@@ -1,0 +1,4 @@
+name: No Blue
+version: 1.0.2
+author: qeaml <qeaml@pm.me>
+desc: Removes all blue from the image.

--- a/pack/effects/nogreen/effect.meta
+++ b/pack/effects/nogreen/effect.meta
@@ -1,4 +1,0 @@
-Name = No green
-Version = 1.1
-Author = qeaml <qeaml@pm.me>
-Desc = Set the green value of all pixels to 0.

--- a/pack/effects/nogreen/effect.yml
+++ b/pack/effects/nogreen/effect.yml
@@ -1,0 +1,4 @@
+name: No green
+version: 1.0.2
+author: qeaml <qeaml@pm.me>
+desc: Removes all green from the image.

--- a/pack/effects/nored/effect.meta
+++ b/pack/effects/nored/effect.meta
@@ -1,4 +1,0 @@
-Name = No red
-Version = 1.1
-Author = qeaml <qeaml@pm.me>
-Desc = Set the red value of all pixels to 0.

--- a/pack/effects/nored/effect.yml
+++ b/pack/effects/nored/effect.yml
@@ -1,0 +1,4 @@
+name: No red
+version: 1.0.2
+author: qeaml <qeaml@pm.me>
+desc: Removes all red from the image.

--- a/pack/effects/offset/effect.meta
+++ b/pack/effects/offset/effect.meta
@@ -1,5 +1,0 @@
-Name = Offset
-Version = 1.0.0
-Author = qeaml <qeaml@pm.me>
-Desc = Offset the image by 1/4 it's vertical/horizontal size.
-Preload = setsize.js

--- a/pack/effects/offset/effect.yml
+++ b/pack/effects/offset/effect.yml
@@ -1,0 +1,6 @@
+name: Offset
+version: 1.0.1
+author: qeaml <qeaml@pm.me>
+desc: Offset the image by 1/4 it's vertical/horizontal size.
+preload:
+  - setsize.js

--- a/src/effect/loader.go
+++ b/src/effect/loader.go
@@ -18,12 +18,12 @@ func Load(path, id string) (*Effect, error) {
 		err         error
 		metaSource  *os.File
 		metaDecoder *yaml.Decoder
+		meta        *Metadata = new(Metadata)
 		script      string
-		meta        *Metadata
 	)
 
-	// Create empty *Metadata
-	meta = new(Metadata)
+	// Populate ID as it's not present in effect.yml
+	meta.ID = id
 	// Open meta file
 	metaSource, err = os.Open(metaPath)
 	if err != nil {

--- a/src/libs/loader.go
+++ b/src/libs/loader.go
@@ -5,36 +5,44 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-	"ximfect/cfg"
 	"ximfect/environ"
+
+	"gopkg.in/yaml.v2"
 )
 
 // Load loads a Lib from the given directory with the given id.
 func Load(path, id string) (*Lib, error) {
 	dir := environ.Combine(path, id)
-	metaPath := environ.Combine(dir, "lib.meta")
+	metaPath := environ.Combine(dir, "lib.yml")
 
 	var (
 		err           error
-		metaSource    string
-		metaParsed    cfg.Config
-		meta          *Metadata
+		metaSource    *os.File
+		metaDecoder   *yaml.Decoder
+		meta          *Metadata = new(Metadata)
 		filesAll      []os.FileInfo
 		filesFiltered []string = []string{}
 		fileName      string
 	)
 
-	metaSource, err = environ.LoadTextfile(metaPath)
+	// Open metadata file
+	metaSource, err = os.Open(metaPath)
 	if err != nil {
 		return nil, fmt.Errorf("error while loading metadata: %v", err)
 	}
-	metaParsed = cfg.Parse(metaSource)
-
+	// Create decoder & read meta
+	metaDecoder = yaml.NewDecoder(metaSource)
+	err = metaDecoder.Decode(meta)
+	if err != nil {
+		return nil, fmt.Errorf("erro while reding metadata: %v", err)
+	}
+	// Get list of all files in lib's folder
 	filesAll, err = ioutil.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("error while discovering library files: %v",
 			err)
 	}
+	// Filter files to only javascript
 	for _, file := range filesAll {
 		fileName = file.Name()
 		if strings.HasSuffix(fileName, ".js") {
@@ -42,36 +50,6 @@ func Load(path, id string) (*Lib, error) {
 		}
 	}
 
-	var (
-		name    string
-		version string
-		author  string
-		desc    string
-		ok      bool
-	)
-
-	name, ok = metaParsed["name"]
-	if !ok {
-		return nil, fmt.Errorf(
-			"error while applying metadata: could not find required field `name`")
-	}
-	version, ok = metaParsed["version"]
-	if !ok {
-		return nil, fmt.Errorf(
-			"error while applying metadata: could not find required field `version`")
-	}
-	author, ok = metaParsed["author"]
-	if !ok {
-		return nil, fmt.Errorf(
-			"error while applying metadata: could not find required field `author`")
-	}
-	desc, ok = metaParsed["desc"]
-	if !ok {
-		return nil, fmt.Errorf(
-			"error while applying metadata: could not find required field `desc`")
-	}
-
-	meta = &(Metadata{name, version, id, author, desc})
 	return NewLib(meta, filesFiltered, dir), nil
 }
 

--- a/src/libs/loader.go
+++ b/src/libs/loader.go
@@ -25,6 +25,8 @@ func Load(path, id string) (*Lib, error) {
 		fileName      string
 	)
 
+	// Populate ID as it's not present in effect.yml
+	meta.ID = id
 	// Open metadata file
 	metaSource, err = os.Open(metaPath)
 	if err != nil {


### PR DESCRIPTION
This PR replaces the old custom metadata format for YAML. The structure remains the same, but the file extensions for effects and libs must be changed from `.meta` to `.yml`.